### PR TITLE
Revert ":fire: remove serializers from push notifications payload"

### DIFF
--- a/openbook_notifications/models/community_invite_notification.py
+++ b/openbook_notifications/models/community_invite_notification.py
@@ -15,9 +15,10 @@ class CommunityInviteNotification(models.Model):
     @classmethod
     def create_community_invite_notification(cls, community_invite_id, owner_id):
         community_invite_notification = cls.objects.create(community_invite_id=community_invite_id)
-        return Notification.create_notification(type=Notification.COMMUNITY_INVITE,
-                                                content_object=community_invite_notification,
-                                                owner_id=owner_id)
+        Notification.create_notification(type=Notification.COMMUNITY_INVITE,
+                                         content_object=community_invite_notification,
+                                         owner_id=owner_id)
+        return community_invite_notification
 
     @classmethod
     def delete_community_invite_notification(cls, community_invite_id, owner_id):

--- a/openbook_notifications/models/connection_confirmed_notification.py
+++ b/openbook_notifications/models/connection_confirmed_notification.py
@@ -15,9 +15,10 @@ class ConnectionConfirmedNotification(models.Model):
     @classmethod
     def create_connection_confirmed_notification(cls, connection_confirmator_id, owner_id):
         connection_confirmed_notification = cls.objects.create(connection_confirmator_id=connection_confirmator_id)
-        return Notification.create_notification(type=Notification.CONNECTION_CONFIRMED,
-                                                content_object=connection_confirmed_notification,
-                                                owner_id=owner_id)
+        Notification.create_notification(type=Notification.CONNECTION_CONFIRMED,
+                                         content_object=connection_confirmed_notification,
+                                         owner_id=owner_id)
+        return connection_confirmed_notification
 
     @classmethod
     def delete_connection_confirmed_notification_for_users_with_ids(cls, user_a_id, user_b_id):

--- a/openbook_notifications/models/connection_request_notification.py
+++ b/openbook_notifications/models/connection_request_notification.py
@@ -15,9 +15,10 @@ class ConnectionRequestNotification(models.Model):
     @classmethod
     def create_connection_request_notification(cls, connection_requester_id, owner_id):
         connection_request_notification = cls.objects.create(connection_requester_id=connection_requester_id)
-        return Notification.create_notification(type=Notification.CONNECTION_REQUEST,
-                                                content_object=connection_request_notification,
-                                                owner_id=owner_id)
+        Notification.create_notification(type=Notification.CONNECTION_REQUEST,
+                                         content_object=connection_request_notification,
+                                         owner_id=owner_id)
+        return connection_request_notification
 
     @classmethod
     def delete_connection_request_notification_for_users_with_ids(cls, user_a_id, user_b_id):

--- a/openbook_notifications/models/follow_notification.py
+++ b/openbook_notifications/models/follow_notification.py
@@ -14,9 +14,10 @@ class FollowNotification(models.Model):
     @classmethod
     def create_follow_notification(cls, follower_id, owner_id):
         follow_notification = cls.objects.create(follower_id=follower_id)
-        return Notification.create_notification(type=Notification.FOLLOW,
-                                                content_object=follow_notification,
-                                                owner_id=owner_id)
+        Notification.create_notification(type=Notification.FOLLOW,
+                                         content_object=follow_notification,
+                                         owner_id=owner_id)
+        return follow_notification
 
     @classmethod
     def delete_follow_notification(cls, follower_id, owner_id):

--- a/openbook_notifications/models/post_comment_notification.py
+++ b/openbook_notifications/models/post_comment_notification.py
@@ -14,9 +14,10 @@ class PostCommentNotification(models.Model):
     @classmethod
     def create_post_comment_notification(cls, post_comment_id, owner_id):
         post_comment_notification = cls.objects.create(post_comment_id=post_comment_id)
-        return Notification.create_notification(type=Notification.POST_COMMENT,
-                                                content_object=post_comment_notification,
-                                                owner_id=owner_id)
+        Notification.create_notification(type=Notification.POST_COMMENT,
+                                         content_object=post_comment_notification,
+                                         owner_id=owner_id)
+        return post_comment_notification
 
     @classmethod
     def delete_post_comment_notification(cls, post_comment_id, owner_id):

--- a/openbook_notifications/models/post_reaction_notification.py
+++ b/openbook_notifications/models/post_reaction_notification.py
@@ -16,15 +16,15 @@ class PostReactionNotification(models.Model):
     @classmethod
     def create_post_reaction_notification(cls, post_reaction_id, owner_id):
         post_reaction_notification = cls.objects.create(post_reaction_id=post_reaction_id)
-        return Notification.create_notification(type=Notification.POST_REACTION,
-                                                content_object=post_reaction_notification,
-                                                owner_id=owner_id)
+        Notification.create_notification(type=Notification.POST_REACTION,
+                                         content_object=post_reaction_notification,
+                                         owner_id=owner_id)
+        return post_reaction_notification
 
     @classmethod
     def delete_post_reaction_notification(cls, post_reaction_id, owner_id):
         cls.objects.filter(post_reaction_id=post_reaction_id,
                            notification__owner_id=owner_id).delete()
-
 
 
 @receiver(pre_delete, sender=PostReactionNotification, dispatch_uid='post_reaction_delete_cleanup')

--- a/openbook_notifications/push_notifications/serializers.py
+++ b/openbook_notifications/push_notifications/serializers.py
@@ -1,0 +1,108 @@
+from rest_framework import serializers
+
+from openbook_common.utils.model_loaders import get_emoji_model, get_post_model, get_post_reaction_model, \
+    get_post_comment_model, get_user_model, get_notification_model, get_community_invite_model, get_community_model
+
+
+# TODO Circular dependency with openbook_auth.models where we call push notification senders which in turn use
+# these serializers, making it impossible to reference to the User model. Redesign. Perhaps make these push
+# notifications, part of a job to be sent async.
+
+class PushNotificationsSerializers:
+    def __init__(self):
+        PostReaction = get_post_reaction_model()
+        PostComment = get_post_comment_model()
+        User = get_user_model()
+        Emoji = get_emoji_model()
+        Post = get_post_model()
+        CommunityInvite = get_community_invite_model()
+        Community = get_community_model()
+
+        class NotificationUserSerializer(serializers.ModelSerializer):
+            class Meta:
+                model = User
+                fields = (
+                    'id',
+                    'username',
+                )
+
+        class NotificationEmojiSerializer(serializers.ModelSerializer):
+            class Meta:
+                model = Emoji
+                fields = (
+                    'id',
+                    'keyword',
+                )
+
+        class NotificationPostSerializer(serializers.ModelSerializer):
+            class Meta:
+                model = Post
+                fields = (
+                    'id',
+                    'uuid',
+                )
+
+        class NotificationPostReactionSerializer(serializers.ModelSerializer):
+            reactor = NotificationUserSerializer()
+            emoji = NotificationEmojiSerializer()
+            post = NotificationPostSerializer()
+
+            class Meta:
+                model = PostReaction
+                fields = (
+                    'id',
+                    'reactor',
+                    'emoji',
+                    'post'
+                )
+
+        self.NotificationPostReactionSerializer = NotificationPostReactionSerializer
+
+        class NotificationCommunitySerializer(serializers.ModelSerializer):
+            class Meta:
+                model = Community
+                fields = (
+                    'id',
+                    'name',
+                    'title'
+                )
+
+        class NotificationCommunityInviteSerializer(serializers.ModelSerializer):
+            creator = NotificationUserSerializer()
+            invited_user = NotificationUserSerializer()
+            community = NotificationCommunitySerializer()
+
+            class Meta:
+                model = CommunityInvite
+                fields = (
+                    'id',
+                    'creator',
+                    'invited_user',
+                    'community'
+                )
+
+        self.NotificationCommunityInviteSerializer = NotificationCommunityInviteSerializer
+
+        class NotificationPostCommentSerializer(serializers.ModelSerializer):
+            commenter = NotificationUserSerializer()
+            post = NotificationPostSerializer()
+
+            class Meta:
+                model = PostComment
+                fields = (
+                    'id',
+                    'commenter',
+                    'post'
+                )
+
+        self.NotificationPostCommentSerializer = NotificationPostCommentSerializer
+
+        class FollowNotificationSerializer(serializers.Serializer):
+            following_user = NotificationUserSerializer()
+
+        self.FollowNotificationSerializer = FollowNotificationSerializer
+
+        class ConnectionRequestNotificationSerializer(serializers.Serializer):
+            connection_requester = NotificationUserSerializer()
+
+        self.ConnectionRequestNotificationSerializer = ConnectionRequestNotificationSerializer


### PR DESCRIPTION
This reverts commit 42d664d949c61edbc33363c7d9e5147322209dca.

# Conflicts:
#	openbook_notifications/push_notifications/senders.py

It will break production if merged already