### PR TITLE
Bugfix/400 Dont send notifications to user if post commenter is blocked

### DIFF
--- a/openbook_auth/models.py
+++ b/openbook_auth/models.py
@@ -722,7 +722,8 @@ class User(AbstractUser):
         PostCommentNotification = get_post_comment_notification_model()
 
         for post_notification_target_user in post_notification_target_users:
-            if not post_notification_target_user.can_see_post(post=post):
+            if not post_notification_target_user.can_see_post(
+                    post=post) or post_notification_target_user.has_blocked_user_with_id(post_commenter.pk):
                 continue
             post_notification_target_user_is_post_creator = post_notification_target_user.id == post_creator.id
             post_notification_target_has_comment_notifications_enabled = post_notification_target_user.has_comment_notifications_enabled_for_post_with_id(


### PR DESCRIPTION
This PR addresses https://github.com/OpenbookOrg/openbook-api/issues/400.

If the post notification target user has the post commenter blocked we will no longer send out notifications about comment updates